### PR TITLE
Llamadas a Kraken OEES vs. OctopusEnergy.es

### DIFF
--- a/custom_components/octopus_spain/const.py
+++ b/custom_components/octopus_spain/const.py
@@ -1,6 +1,7 @@
 """Constants for Octopus Energy Spain."""
 
 DOMAIN = "octopus_spain"
+GRAPH_QL_ENDPOINT = "https://api.oees-kraken.energy/v1/graphql/"
 
 CONF_EMAIL = 'email'
 CONF_PASSWORD = 'password'


### PR DESCRIPTION
Octopus Energy España utiliza dos servidores de GraphQL, uno de backend y otro de front. Previamente se hacían dos llamadas a el de front y la llamada final al de back. Este commit cambia el endpoint para que siempre se haga al de back (mejor mantenido, mas estable y el correcto) y introduce cambios en las queries para retornar la misma informacion desde ese servidor.