### PR TITLE
Fix KeyError: 'octopus_credit' when account has no invoices

### DIFF
--- a/custom_components/octopus_spain/lib/octopus_spain.py
+++ b/custom_components/octopus_spain/lib/octopus_spain.py
@@ -87,6 +87,7 @@ class OctopusSpain:
         if len(invoices) == 0:
             return {
                 'solar_wallet': None,
+                'octopus_credit': None,
                 'last_invoice': {
                     'amount': None,
                     'issued': None,

--- a/custom_components/octopus_spain/sensor.py
+++ b/custom_components/octopus_spain/sensor.py
@@ -82,7 +82,7 @@ class OctopusWallet(CoordinatorEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._state = self.coordinator.data[self._account][self._key]
+        self._state = self.coordinator.data[self._account].get(self._key)
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
## Bug

When an account has no invoices, `account()` in `lib/octopus_spain.py` returns
an early-return dict that is missing the `octopus_credit` key. Then `sensor.py`
line 85 does:


self._state = self.coordinator.data[self._account][self._key]
This raises KeyError: 'octopus_credit' for any user whose account has no
invoice history yet.

Fix
lib/octopus_spain.py: Add 'octopus_credit': None to the early-return dict so it has the same shape as the full-return dict.
sensor.py: Use .get(self._key) instead of [self._key] for defensive access — missing keys return None instead of raising KeyError