### PR TITLE
Fix last-invoice sensors: read from account.bills (statementsWithDetails returns empty)

### DIFF
--- a/custom_components/octopus_spain/lib/octopus_spain.py
+++ b/custom_components/octopus_spain/lib/octopus_spain.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from python_graphql_client import GraphqlClient
 
@@ -57,17 +57,21 @@ class OctopusSpain:
               accountBillingInfo(accountNumber: $account) {
                 ledgers {
                   ledgerType
-                  statementsWithDetails(first: 1) {
-                    edges {
-                      node {
-                        amount
-                        consumptionStartDate
-                        consumptionEndDate
-                        issuedDate
+                  balance
+                }
+              }
+              account(accountNumber: $account) {
+                bills(first: 1) {
+                  edges {
+                    node {
+                      issuedDate
+                      fromDate
+                      toDate
+                      ... on InvoiceType {
+                        grossAmount
                       }
                     }
                   }
-                  balance
                 }
               }
             }
@@ -75,18 +79,20 @@ class OctopusSpain:
         headers = {"authorization": self._token}
         client = GraphqlClient(endpoint=GRAPH_QL_ENDPOINT, headers=headers)
         response = await client.execute_async(query, {"account": account})
-        ledgers = response["data"]["accountBillingInfo"]["ledgers"]
+        data = response["data"]
+        ledgers = data["accountBillingInfo"]["ledgers"]
         electricity = next(filter(lambda x: x['ledgerType'] == ELECTRICITY_LEDGER, ledgers), None)
         solar_wallet = next(filter(lambda x: x['ledgerType'] == SOLAR_WALLET_LEDGER, ledgers), {'balance': 0})
 
         if not electricity:
             raise Exception("Electricity ledger not found")
 
-        invoices = electricity["statementsWithDetails"]["edges"]
+        bills = data.get("account", {}).get("bills", {}).get("edges", [])
 
-        if len(invoices) == 0:
+        if len(bills) == 0:
             return {
-                'solar_wallet': None,
+                'solar_wallet': (float(solar_wallet["balance"]) / 100),
+                'octopus_credit': (float(electricity["balance"]) / 100),
                 'last_invoice': {
                     'amount': None,
                     'issued': None,
@@ -95,16 +101,15 @@ class OctopusSpain:
                 }
             }
 
-        invoice = invoices[0]["node"]
+        invoice = bills[0]["node"]
 
-        # Los timedelta son bastante chapuzas, habrá que arreglarlo
         return {
             "solar_wallet": (float(solar_wallet["balance"]) / 100),
             "octopus_credit": (float(electricity["balance"]) / 100),
             "last_invoice": {
-                "amount": invoice["amount"] if invoice["amount"] else 0,
+                "amount": (float(invoice["grossAmount"]) / 100) if invoice.get("grossAmount") is not None else 0,
                 "issued": datetime.fromisoformat(invoice["issuedDate"]).date(),
-                "start": (datetime.fromisoformat(invoice["consumptionStartDate"]) + timedelta(hours=2)).date(),
-                "end": (datetime.fromisoformat(invoice["consumptionEndDate"]) - timedelta(seconds=1)).date(),
+                "start": datetime.fromisoformat(invoice["fromDate"]).date(),
+                "end": datetime.fromisoformat(invoice["toDate"]).date(),
             },
         }


### PR DESCRIPTION
## Problem
On Spanish accounts the last-invoice sensors (`ultima_factura_octopus`, `solar_wallet`, `octopus_credit`) break — wallet/invoice go `unknown` and `octopus_credit` raises `KeyError`.

## Cause
`account()` reads invoices from `ledgers[].statementsWithDetails`, which now returns zero edges for Spanish electricity ledgers.

## Fix
Read invoices from `account.bills` → `InvoiceType.grossAmount` instead. Ledger balances are unchanged, and the no-invoice branch now also returns them so `octopus_credit` no longer raises.

## Verification
Tested against a live account: invoice total returns correctly (e.g. 61.11 €) and wallet/credit populate.

<img width="853" height="358" alt="image" src="https://github.com/user-attachments/assets/8c9c9a17-2096-421c-a3a1-574e37311f74" />
<img width="863" height="230" alt="image" src="https://github.com/user-attachments/assets/7c5cb66c-8a06-4b44-8584-ab62edd59012" />
<img width="852" height="296" alt="image" src="https://github.com/user-attachments/assets/c4f2ec03-637a-413b-801e-a793c624d043" />
