### PR TITLE
Add tariff price sensors (current / peak / standard / valley / surplus)

### DIFF
--- a/custom_components/octopus_spain/lib/octopus_spain.py
+++ b/custom_components/octopus_spain/lib/octopus_spain.py
@@ -73,6 +73,19 @@ class OctopusSpain:
                     }
                   }
                 }
+                properties {
+                  electricitySupplyPoints {
+                    activeAgreement {
+                      product {
+                        prices(decimalPlaces: 6) {
+                          variableTerm
+                          variableTermWithTaxes
+                          surplusRate
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
         """
@@ -90,26 +103,42 @@ class OctopusSpain:
         bills = data.get("account", {}).get("bills", {}).get("edges", [])
 
         if len(bills) == 0:
-            return {
-                'solar_wallet': (float(solar_wallet["balance"]) / 100),
-                'octopus_credit': (float(electricity["balance"]) / 100),
-                'last_invoice': {
-                    'amount': None,
-                    'issued': None,
-                    'start': None,
-                    'end': None
-                }
-            }
-
-        invoice = bills[0]["node"]
-
-        return {
-            "solar_wallet": (float(solar_wallet["balance"]) / 100),
-            "octopus_credit": (float(electricity["balance"]) / 100),
-            "last_invoice": {
+            last_invoice = {'amount': None, 'issued': None, 'start': None, 'end': None}
+        else:
+            invoice = bills[0]["node"]
+            last_invoice = {
                 "amount": (float(invoice["grossAmount"]) / 100) if invoice.get("grossAmount") is not None else 0,
                 "issued": datetime.fromisoformat(invoice["issuedDate"]).date(),
                 "start": datetime.fromisoformat(invoice["fromDate"]).date(),
                 "end": datetime.fromisoformat(invoice["toDate"]).date(),
-            },
+            }
+
+        return {
+            "solar_wallet": (float(solar_wallet["balance"]) / 100),
+            "octopus_credit": (float(electricity["balance"]) / 100),
+            "last_invoice": last_invoice,
+            "prices": self._prices(data.get("account", {})),
         }
+
+    @staticmethod
+    def _prices(account_data: dict):
+        for prop in account_data.get("properties", []) or []:
+            for spp in prop.get("electricitySupplyPoints", []) or []:
+                product = (spp.get("activeAgreement") or {}).get("product") or {}
+                prices = product.get("prices")
+                if not prices:
+                    continue
+                variable = prices.get("variableTerm")
+                with_taxes = prices.get("variableTermWithTaxes")
+                if isinstance(variable, list) and len(variable) == 3:
+                    has_taxes = isinstance(with_taxes, list) and len(with_taxes) == 3
+                    return {
+                        "peak": variable[0],
+                        "standard": variable[1],
+                        "valley": variable[2],
+                        "peak_with_taxes": with_taxes[0] if has_taxes else None,
+                        "standard_with_taxes": with_taxes[1] if has_taxes else None,
+                        "valley_with_taxes": with_taxes[2] if has_taxes else None,
+                        "surplus": prices.get("surplusRate"),
+                    }
+        return None

--- a/custom_components/octopus_spain/manifest.json
+++ b/custom_components/octopus_spain/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/MiguelAngelLV/octopus_spain",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MiguelAngelLV/issues",
-  "requirements": ["python-graphql-client==0.4.3"],
+  "requirements": ["python-graphql-client==0.4.3", "tariff-td==1.1"],
   "version": "0.1.0"
 }

--- a/custom_components/octopus_spain/sensor.py
+++ b/custom_components/octopus_spain/sensor.py
@@ -2,6 +2,9 @@ import logging
 from datetime import timedelta
 from typing import Mapping, Any
 
+import homeassistant.util.dt as dt_util
+from tariff_td import Tariff20TD
+from homeassistant.helpers.event import async_track_time_change
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, CoordinatorEntity
 from .const import (
@@ -23,6 +26,9 @@ from .lib.octopus_spain import OctopusSpain
 
 _LOGGER = logging.getLogger(__name__)
 
+PRICE_PER_KWH = "€/kWh"
+PERIOD_KEY = {"P1": "peak", "P2": "standard", "P3": "valley"}
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     email = entry.data[CONF_EMAIL]
@@ -33,10 +39,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     await coordinator.async_config_entry_first_refresh()
 
     accounts = coordinator.data.keys()
+    single = len(accounts) == 1
     for account in accounts:
-        sensors.append(OctopusWallet(account, 'solar_wallet', 'Solar Wallet', coordinator, len(accounts) == 1))
-        sensors.append(OctopusWallet(account, 'octopus_credit', 'Octopus Credit', coordinator, len(accounts) == 1))
-        sensors.append(OctopusInvoice(account, coordinator, len(accounts) == 1))
+        sensors.append(OctopusWallet(account, 'solar_wallet', 'Solar Wallet', coordinator, single))
+        sensors.append(OctopusWallet(account, 'octopus_credit', 'Octopus Credit', coordinator, single))
+        sensors.append(OctopusInvoice(account, coordinator, single))
+        if coordinator.data[account].get('prices'):
+            sensors.append(OctopusCurrentPrice(account, coordinator, single))
+            sensors.append(OctopusPrice(account, 'peak', 'Precio Punta', coordinator, single))
+            sensors.append(OctopusPrice(account, 'standard', 'Precio Llano', coordinator, single))
+            sensors.append(OctopusPrice(account, 'valley', 'Precio Valle', coordinator, single))
+            sensors.append(OctopusPrice(account, 'surplus', 'Precio Excedente', coordinator, single))
 
     async_add_entities(sensors)
 
@@ -120,6 +133,97 @@ class OctopusInvoice(CoordinatorEntity, SensorEntity):
             'Fin': data['end'],
             'Emitida': data['issued']
         }
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> StateType:
+        return self._state
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        return self._attrs
+
+
+class OctopusPrice(CoordinatorEntity, SensorEntity):
+
+    def __init__(self, account: str, key: str, name: str, coordinator, single: bool):
+        super().__init__(coordinator=coordinator)
+        self._state = None
+        self._key = key
+        self._account = account
+        self._attrs: Mapping[str, Any] = {}
+        self._attr_name = f"{name}" if single else f"{name} ({account})"
+        self._attr_unique_id = f"{key}_price_{account}"
+        self.entity_description = SensorEntityDescription(
+            key=f"{key}_price_{account}",
+            icon="mdi:transmission-tower-export" if key == "surplus" else "mdi:transmission-tower",
+            native_unit_of_measurement=PRICE_PER_KWH,
+            state_class=SensorStateClass.MEASUREMENT
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        prices = self.coordinator.data[self._account].get('prices') or {}
+        if self._key == "surplus":
+            self._state = prices.get("surplus")
+        else:
+            self._state = prices.get(f"{self._key}_with_taxes")
+            self._attrs = {"without_taxes": prices.get(self._key)}
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> StateType:
+        return self._state
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        return self._attrs
+
+
+class OctopusCurrentPrice(CoordinatorEntity, SensorEntity):
+
+    def __init__(self, account: str, coordinator, single: bool):
+        super().__init__(coordinator=coordinator)
+        self._state = None
+        self._account = account
+        self._attrs: Mapping[str, Any] = {}
+        self._attr_name = "Precio Actual" if single else f"Precio Actual ({account})"
+        self._attr_unique_id = f"current_price_{account}"
+        self.entity_description = SensorEntityDescription(
+            key=f"current_price_{account}",
+            icon="mdi:transmission-tower-import",
+            native_unit_of_measurement=PRICE_PER_KWH,
+            state_class=SensorStateClass.MEASUREMENT
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self.async_on_remove(async_track_time_change(self.hass, self._tick, minute=0, second=10))
+        self._update()
+
+    @callback
+    def _tick(self, now) -> None:
+        self._update()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._update()
+
+    def _update(self) -> None:
+        prices = self.coordinator.data[self._account].get('prices') or {}
+        tariff = Tariff20TD(
+            p1=prices.get("peak_with_taxes"),
+            p2=prices.get("standard_with_taxes"),
+            p3=prices.get("valley_with_taxes"),
+        )
+        now = dt_util.now()
+        period = tariff.get_period(now)
+        self._state = tariff.get_price(now)
+        self._attrs = {"period": period, "without_taxes": prices.get(PERIOD_KEY.get(period))}
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
## What
New sensors exposing the contract's energy prices from `product.prices`:

| Sensor | Value |
|---|---|
| **Precio Actual** | current 2.0TD period price (with taxes); `period` (P1/P2/P3) + `without_taxes` attributes |
| **Precio Punta / Llano / Valle** | the three period prices (with taxes); `without_taxes` attribute |
| **Precio Excedente** | surplus / export rate (`surplusRate`) |

## How
`account()` also queries `account.properties[].electricitySupplyPoints[].activeAgreement.product.prices` (`variableTerm`, `variableTermWithTaxes`, `surplusRate`). `Precio Actual` resolves the current period with `tariff-td`'s `Tariff20TD` (handles weekends + Spanish national holidays) and refreshes hourly.

## Scope / limitations
- Sensors are only created when the product returns a 3-period `variableTerm` array — i.e. **2.0TD fixed tariffs**. Flat, 3.0TD (6-period) and PVPC/indexed accounts simply don't get them (no crash, just absent).
- PVPC/indexed not tested (no such account available).

## Verified
Live 2.0TD account: Punta 0.2560 / Llano 0.1518 / Valle 0.1228 €/kWh (with taxes), surplus 0.04, `without_taxes` matching the bill's per-period rates. Holidays (Christmas, New Year) resolve to valley; Good Friday to peak.
